### PR TITLE
Modify Spherical Aberration to work via per-sample exposure instead

### DIFF
--- a/src/DepthOfFieldController.cpp
+++ b/src/DepthOfFieldController.cpp
@@ -285,7 +285,7 @@ void DepthOfFieldController::performRenderFrameSetupWork()
 	_xAlignmentDelta = currentFrameData.xAlignmentDelta;
 	_yAlignmentDelta = currentFrameData.yAlignmentDelta;
 	_frameWaitCounter = _numberOfFramesToWaitPerFrame;
-	_blendFactor = 1.0f / (static_cast<float>(_currentFrame) + 2.0f);		// frame start at 0 so +1, and we have to blend the original too, so +1
+	_blendFactor = 1.0f / (static_cast<float>(_currentFrame) + 1.0f);		// frame start at 0 so +1, to get 1/1=100% blend factor for first frame
 	_highLightBoostForFrame = _highlightBoostFactor * currentFrameData.busyBokehFactor;
 	// Set the framestate to wait so the counter will take effect.
 	_renderFrameState = DepthOfFieldRenderFrameState::FrameWait;
@@ -395,6 +395,8 @@ void DepthOfFieldController::createCircleDoFPoints()
 {
 	_cameraSteps.clear();
 
+	_cameraSteps.push_back({0.0f, 0.0f, 0.0f, 0.0f, 1.0f}); //center
+
 	const float pointsFirstRing = (float)_numberOfPointsInnermostRing;
 	float pointsOnRing = pointsFirstRing;
 	const float maxBokehRadius = _maxBokehSize / 2.0f;
@@ -442,6 +444,7 @@ void DepthOfFieldController::createCircleDoFPoints()
 void DepthOfFieldController::createApertureShapedDoFPoints()
 {
 	_cameraSteps.clear();
+	_cameraSteps.push_back({0.0f, 0.0f, 0.0f, 0.0f, 1.0f}); //center
 
 	// sanitize input for 4 vertex elements
 	if(4 == _apertureShapeSettings.NumberOfVertices)

--- a/src/DepthOfFieldController.h
+++ b/src/DepthOfFieldController.h
@@ -57,7 +57,8 @@ class DepthOfFieldController
 		float yDelta = 0.0f;
 		float xAlignmentDelta = 0.0f;
 		float yAlignmentDelta = 0.0f;
-		float busyBokehFactor = 1.0f;
+
+		float sampleWeightRGB[3] = {1.0f, 1.0f, 1.0f};
 	};
 
 	struct MagnifierSettings
@@ -247,8 +248,9 @@ private:
 	/// Calculates the spherical aberration factor to use for camera steps using the actual current ring in the shape
 	/// </summary>
 	/// <param name="ringNo"></param>
+	/// <param name="weightsRGB"></param>
 	/// <returns></returns>
-	float calculateSphericalAberrationFactorToUse(float radiusNormalized);
+	void applySphericalAberration(float radiusNormalized, CameraLocation& sample);
 	/// <summary>
 	/// Method which will setup the frame for blending, moving the camera, configuring the shader.
 	/// </summary>
@@ -274,7 +276,9 @@ private:
 	float _highlightBoostFactor = 0.9f;
 	float _highlightGammaFactor = 2.2f;
 	float _sphericalAberrationDimFactor = 0.5f; //dim factor as intensity, 0% to 100% for center sample
-	float _sphericalAberrationDimFactorForFrame = 1.0f; //per-sample weight for spherical aberration
+	//float _sphericalAberrationDimFactorForFrame = 1.0f; //per-sample weight for spherical aberration
+	float _sampleWeightRGB[3] = {1.0f, 1.0f, 1.0f};
+
 	MagnifierSettings _magnificationSettings;
 
 	int _onPresentWorkCounter = 0;		// if 0, reshadeBeginEffectsCalled will call onPresentWorkFunc (if set), otherwise this counter is decreased.

--- a/src/DepthOfFieldController.h
+++ b/src/DepthOfFieldController.h
@@ -182,6 +182,16 @@ public:
 		_sphericalAberrationDimFactor = IGCS::Utils::clampEx(newValue, 0.0f, 1.0f);
 		calculateShapePoints();
 	}
+	void setFringeIntensity(float newValue)
+	{
+		_fringeIntensity = IGCS::Utils::clampEx(newValue, 0.0f, 1.0f);
+		calculateShapePoints();
+	}
+	void setFringeWidth(float newValue)
+	{
+		_fringeWidth = IGCS::Utils::clampEx(newValue, 0.0f, 1.0f);
+		calculateShapePoints();
+	}
 	void setRenderOrder(DepthOfFieldRenderOrder newValue)
 	{
 		_renderOrder = newValue;
@@ -208,6 +218,8 @@ public:
 	float getAnamorphicFactor() { return _anamorphicFactor; }
 	float getRingAngleOffset() { return _ringAngleOffset; }
 	float getSphericalAberrationDimFactor() { return _sphericalAberrationDimFactor; }
+	float getFringeIntensity() { return _fringeIntensity; }
+	float getFringeWidth() { return _fringeWidth; }
 
 	MagnifierSettings& getMagnifierSettings() { return _magnificationSettings; }		// this is a bit dirty...
 	ApertureShapeSettings& getApertureShapeSettings() { return _apertureShapeSettings; }						// same
@@ -245,12 +257,19 @@ private:
 	/// </summary>
 	void handlePresentAfterReshadeEffects();
 	/// <summary>
-	/// Calculates the spherical aberration factor to use for camera steps using the actual current ring in the shape
+	/// Modifies the sample weight for the camera steps to produce spherical aberration based on radius from center
 	/// </summary>
-	/// <param name="ringNo"></param>
+	/// <param name="radiusNormalized"></param>
 	/// <param name="weightsRGB"></param>
 	/// <returns></returns>
 	void applySphericalAberration(float radiusNormalized, CameraLocation& sample);
+	/// <summary>
+	/// Calculates the factor of the bokeh disc outline (fringe)
+	/// </summary>
+	/// <param name="radiusNormalized"></param>
+	/// <param name="weightsRGB"></param>
+	/// <returns></returns>
+	void applyFringe(float ringRadiusNormalized, int numRings, CameraLocation& sample);
 	/// <summary>
 	/// Method which will setup the frame for blending, moving the camera, configuring the shader.
 	/// </summary>
@@ -276,7 +295,8 @@ private:
 	float _highlightBoostFactor = 0.9f;
 	float _highlightGammaFactor = 2.2f;
 	float _sphericalAberrationDimFactor = 0.5f; //dim factor as intensity, 0% to 100% for center sample
-	//float _sphericalAberrationDimFactorForFrame = 1.0f; //per-sample weight for spherical aberration
+	float _fringeIntensity = 0.0f;
+	float _fringeWidth = 0.1f;
 	float _sampleWeightRGB[3] = {1.0f, 1.0f, 1.0f};
 
 	MagnifierSettings _magnificationSettings;

--- a/src/DepthOfFieldController.h
+++ b/src/DepthOfFieldController.h
@@ -245,6 +245,8 @@ private:
 	/// Create a set of circular points using nested circles, which are used to build the camera steps array
 	/// </summary>
 	void createCircleDoFPoints();
+	void applyRenderOrder();
+	void renormalizeBokehWeights();
 	void createApertureShapedDoFPoints();
 
 	void displayScreenshotSessionStartError(const ScreenshotSessionStartReturnCode sessionStartResult);
@@ -260,14 +262,15 @@ private:
 	/// Modifies the sample weight for the camera steps to produce spherical aberration based on radius from center
 	/// </summary>
 	/// <param name="radiusNormalized"></param>
-	/// <param name="weightsRGB"></param>
+	/// <param name="sample"></param>
 	/// <returns></returns>
 	void applySphericalAberration(float radiusNormalized, CameraLocation& sample);
 	/// <summary>
 	/// Calculates the factor of the bokeh disc outline (fringe)
 	/// </summary>
-	/// <param name="radiusNormalized"></param>
-	/// <param name="weightsRGB"></param>
+	/// <param name="ringRadiusNormalized"></param>
+	/// <param name="numRings"></param>
+	/// <param name="sample"></param>
 	/// <returns></returns>
 	void applyFringe(float ringRadiusNormalized, int numRings, CameraLocation& sample);
 	/// <summary>

--- a/src/DepthOfFieldController.h
+++ b/src/DepthOfFieldController.h
@@ -248,7 +248,7 @@ private:
 	/// </summary>
 	/// <param name="ringNo"></param>
 	/// <returns></returns>
-	float calculateSphericalAberrationFactorToUse(int ringNo);
+	float calculateSphericalAberrationFactorToUse(float radiusNormalized);
 	/// <summary>
 	/// Method which will setup the frame for blending, moving the camera, configuring the shader.
 	/// </summary>

--- a/src/DepthOfFieldController.h
+++ b/src/DepthOfFieldController.h
@@ -176,11 +176,6 @@ public:
 		_ringAngleOffset = IGCS::Utils::clampEx(newValue, -2.0f, 2.0f);
 		calculateShapePoints();
 	}
-	void setSphericalAberrationFactor(float newValue)
-	{
-		_sphericalAberrationFactor = IGCS::Utils::clampEx(newValue, 0.0f, 1.0f);
-		calculateShapePoints();
-	}
 	void setSphericalAberrationDimFactor(float newValue)
 	{
 		_sphericalAberrationDimFactor = IGCS::Utils::clampEx(newValue, 0.0f, 1.0f);
@@ -211,7 +206,6 @@ public:
 	bool getShowProgressBarAsOverlay() { return _showProgressBarAsOverlay; }
 	float getAnamorphicFactor() { return _anamorphicFactor; }
 	float getRingAngleOffset() { return _ringAngleOffset; }
-	float getSphericalAberrationFactor() { return _sphericalAberrationFactor; }
 	float getSphericalAberrationDimFactor() { return _sphericalAberrationDimFactor; }
 
 	MagnifierSettings& getMagnifierSettings() { return _magnificationSettings; }		// this is a bit dirty...
@@ -250,12 +244,11 @@ private:
 	/// </summary>
 	void handlePresentAfterReshadeEffects();
 	/// <summary>
-	/// Calculates the spherical aberration factor to use for camera steps using the actual current ring in the shape and teh start ring number that's boosted
+	/// Calculates the spherical aberration factor to use for camera steps using the actual current ring in the shape
 	/// </summary>
-	/// <param name="startRingBoosted"></param>
 	/// <param name="ringNo"></param>
 	/// <returns></returns>
-	float calculateSphericalAberrationFactorToUse(const int startRingBoosted, int ringNo);
+	float calculateSphericalAberrationFactorToUse(int ringNo);
 	/// <summary>
 	/// Method which will setup the frame for blending, moving the camera, configuring the shader.
 	/// </summary>
@@ -280,9 +273,8 @@ private:
 	float _yAlignmentDelta = 0.0f;		// for the shader, the alignment y delta to use
 	float _highlightBoostFactor = 0.9f;
 	float _highlightGammaFactor = 2.2f;
-	float _highLightBoostForFrame = 0.0f;
-	float _sphericalAberrationFactor = 0.0f;
-	float _sphericalAberrationDimFactor = 0.5f;
+	float _sphericalAberrationDimFactor = 0.5f; //dim factor as intensity, 0% to 100% for center sample
+	float _sphericalAberrationDimFactorForFrame = 1.0f; //per-sample weight for spherical aberration
 	MagnifierSettings _magnificationSettings;
 
 	int _onPresentWorkCounter = 0;		// if 0, reshadeBeginEffectsCalled will call onPresentWorkFunc (if set), otherwise this counter is decreased.

--- a/src/IgcsConnector.rc
+++ b/src/IgcsConnector.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,2,2,0
- PRODUCTVERSION 2,2,2,0
+ FILEVERSION 2,3,0,0
+ PRODUCTVERSION 2,3,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Frans 'Otis_Inf' Bouma"
             VALUE "FileDescription", "IGCS Connection Addon for ReShade 5.8+"
-            VALUE "FileVersion", "2.2.3.0"
+            VALUE "FileVersion", "2.3.0.0"
             VALUE "InternalName", "IgcsConnector.dll"
             VALUE "LegalCopyright", "Copyright (C) 2023 Frans Bouma"
             VALUE "OriginalFilename", "IgcsConnector.dll"
             VALUE "ProductName", "IGCS Connection addon for ReShade 5.8+"
-            VALUE "ProductVersion", "2.2.3.0"
+            VALUE "ProductVersion", "2.3.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -594,17 +594,7 @@ static void displaySettings(reshade::api::effect_runtime* runtime)
 							if(changed)
 							{
 								g_depthOfFieldController.setAnamorphicFactor(anamorphicFactor);
-							}
-							float sphericalAberrationFactor = g_depthOfFieldController.getSphericalAberrationFactor();
-							changed = ImGui::DragFloat("Spherical aberration factor", &sphericalAberrationFactor, 0.001f, 0.0f, 1.0f);
-							if(ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
-							{
-								ImGui::SetTooltip("The factor for dimming center pixels in bokeh highlights\n0 means no pixels are dimmed, 1.0 means only the outer ring isn't dimmed.");
-							}
-							if(changed)
-							{
-								g_depthOfFieldController.setSphericalAberrationFactor(sphericalAberrationFactor);
-							}
+							}							
 							float sphericalAberrationDimFactor = g_depthOfFieldController.getSphericalAberrationDimFactor();
 							changed = ImGui::DragFloat("Spherical aberration dim factor", &sphericalAberrationDimFactor, 0.001f, 0.0f, 1.0f);
 							if(ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -606,6 +606,28 @@ static void displaySettings(reshade::api::effect_runtime* runtime)
 								g_depthOfFieldController.setSphericalAberrationDimFactor(sphericalAberrationDimFactor);
 							}
 
+							float fringeIntensity = g_depthOfFieldController.getFringeIntensity();
+							changed = ImGui::DragFloat("Fringe Intensity", &fringeIntensity, 0.001f, 0.0f, 1.0f);
+							if(ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
+							{
+								ImGui::SetTooltip("Intensity of bokeh outline");
+							}
+							if(changed)
+							{
+								g_depthOfFieldController.setFringeIntensity(fringeIntensity);
+							}
+
+							float fringeWidth = g_depthOfFieldController.getFringeWidth();
+							changed = ImGui::DragFloat("Fringe Width", &fringeWidth, 0.001f, 0.0f, 1.0f);
+							if(ImGui::IsItemHovered(ImGuiHoveredFlags_DelayShort))
+							{
+								ImGui::SetTooltip("Width of bokeh outline");
+							}
+							if(changed)
+							{
+								g_depthOfFieldController.setFringeWidth(fringeWidth);
+							}
+
 							int renderOrder = (int)g_depthOfFieldController.getRenderOrder();
 							changed = ImGui::Combo("Render order", &renderOrder, "Inner to outer ring\0Outer to inner ring\0Random\0\0");
 							if(changed)

--- a/src/Shader/IgcsDof.fx
+++ b/src/Shader/IgcsDof.fx
@@ -65,12 +65,27 @@ namespace IgcsDOF
 		ui_step = 0.001;
 		hidden=true;
 	> = 0.50;
-	uniform float SphericalAberrationDimFactorForFrame <
-		ui_category = "Spherical Aberration";
-		ui_label="Spherical Aberration Dim Factor for Frame";
+	uniform float SampleWeightR <
+		ui_category = "Sample Weight Red";
+		ui_label="Sample Weight for Red Channel for current sample";
 		ui_type = "drag";
-		ui_min = 0.00; ui_max = 1.00;
-		ui_tooltip = "Will weight each frame to produce spherical aberration";
+		ui_min = 0.00; ui_max = 10.00;
+		ui_step = 0.001;
+		hidden=true;
+	> = 1.0;
+	uniform float SampleWeightG <
+		ui_category = "Sample Weight Green";
+		ui_label="Sample Weight for Green Channel for current sample";
+		ui_type = "drag";
+		ui_min = 0.00; ui_max = 10.00;
+		ui_step = 0.001;
+		hidden=true;
+	> = 1.0;
+	uniform float SampleWeightB <
+		ui_category = "Sample Weight Blue";
+		ui_label="Sample Weight for Blue Channel for current sample";
+		ui_type = "drag";
+		ui_min = 0.00; ui_max = 10.00;
 		ui_step = 0.001;
 		hidden=true;
 	> = 1.0;
@@ -267,7 +282,7 @@ namespace IgcsDOF
 				{
 					float3 currentFragment = tex2Dlod(ReShade::BackBuffer, float4(texCoordToReadFrom, 0.0f, 0.0f)).rgb;
 					currentFragment = AccentuateWhites(currentFragment);
-					currentFragment *= SphericalAberrationDimFactorForFrame; //adjust exposure of current sample here
+					currentFragment *= float3(SampleWeightR, SampleWeightG, SampleWeightB); 
 					fragment = float4(currentFragment, BlendFactor);
 				}				
 			}					

--- a/src/Shader/IgcsDof.fx
+++ b/src/Shader/IgcsDof.fx
@@ -65,6 +65,15 @@ namespace IgcsDOF
 		ui_step = 0.001;
 		hidden=true;
 	> = 0.50;
+	uniform float SphericalAberrationDimFactorForFrame <
+		ui_category = "Spherical Aberration";
+		ui_label="Spherical Aberration Dim Factor for Frame";
+		ui_type = "drag";
+		ui_min = 0.00; ui_max = 1.00;
+		ui_tooltip = "Will weight each frame to produce spherical aberration";
+		ui_step = 0.001;
+		hidden=true;
+	> = 1.0;
 	uniform float HighlightGammaFactor <
 		ui_category = "Highlight tweaking";
 		ui_label="Highlight gamma factor";
@@ -259,6 +268,7 @@ namespace IgcsDOF
 				{
 					float3 currentFragment = tex2Dlod(ReShade::BackBuffer, float4(texCoordToReadFrom, 0.0f, 0.0f)).rgb;
 					currentFragment = AccentuateWhites(currentFragment);
+					currentFragment *= SphericalAberrationDimFactorForFrame; //adjust exposure of current sample here
 					fragment = float4(currentFragment, BlendFactor);
 				}				
 			}					

--- a/src/Shader/IgcsDof.fx
+++ b/src/Shader/IgcsDof.fx
@@ -208,12 +208,11 @@ namespace IgcsDOF
 	}
 
 
-	void PS_HandleStateStart(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float3 fragment0 : SV_Target0)
+	void PS_HandleStateStart(float4 vpos : SV_Position, float2 texcoord : TEXCOORD, out float3 fragment : SV_Target0)
 	{
 		if(SessionState==1)
 		{
-			float3 currentFragment = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0, 0)).rgb;
-			fragment0 = AccentuateWhites(currentFragment);
+			fragment = tex2Dlod(ReShade::BackBuffer, float4(texcoord, 0, 0)).rgb;
 		}
 		else
 		{
@@ -227,7 +226,7 @@ namespace IgcsDOF
 		if(SessionState==2)
 		{
 			float3 currentFragment = tex2Dlod(ReShade::BackBuffer, float4(texcoord.x - FocusDelta, texcoord.y, 0, 0)).rgb;
-			float3 cachedFragment = CorrectForWhiteAccentuation(tex2Dlod(SamplerBlendAccumulate, float4(texcoord, 0, 0)).rgb); //undo cached accentuation
+			float3 cachedFragment = tex2Dlod(SamplerBlendAccumulate, float4(texcoord, 0, 0)).rgb;
 			fragment = lerp(cachedFragment, currentFragment, SetupAlpha);
 		}
 		else


### PR DESCRIPTION
As discussed on Discord recently. 

For the curve itself, I looked at https://jtra.cz/stuff/essays/bokeh/index.html and figured out something that both looks relatively accurate to the plotted graph and results in (imho) pleasing results. Just lerping between radius^4 and 1.0.

https://www.desmos.com/calculator/9oogkblrwx

Something that could be useful is being able to adjust the exponent to produce a harsher or softer ring but I'll leave that up to your preferences.